### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,10 @@ target/
 
 bin/
 out/
+build/
 eclipse_plugin/lib/
+
+.gradle/
+**/gradle/wrapper/
+gradlew
+gradlew.bat


### PR DESCRIPTION
This updates the .gitignore to ignore intellij/gradle artifacts for
the intellij plugin.